### PR TITLE
fix/user-reset-issue

### DIFF
--- a/kw_webapp/models.py
+++ b/kw_webapp/models.py
@@ -90,14 +90,24 @@ class Profile(models.Model):
         x = [x[0] for x in x]
         return x
 
+    def handle_wanikani_level_change(self, new_level):
+        original_level = self.level
+        self.level = new_level
+        self.save()
+
+        #The case of a user resetting their WK profile.
+        if new_level < original_level:
+            expired_levels = self.unlocked_levels.filter(level__gt=new_level)
+            expired_levels.delete()
+
+            expired_reviews = self.get_overleveled_reviews()
+            expired_reviews.delete()
+
+    def get_overleveled_reviews(self):
+        return UserSpecific.objects.filter(user=self.user, vocabulary__reading__level__gt=self.user.profile.level)
+
     def __str__(self):
         return "{} -- {} -- {} -- {}".format(self.user.username, self.api_key, self.level, self.unlocked_levels_list())
-
-    def is_being_followed(self):
-        if self.level in self.unlocked_levels_list():
-            return True
-        else:
-            return False
 
 
 class Vocabulary(models.Model):
@@ -175,16 +185,18 @@ class UserSpecific(models.Model):
     def _round_review_time_up(self):
         original_date = self.next_review_date
         round_to = constants.REVIEW_ROUNDING_TIME.total_seconds()
-        seconds = (self.next_review_date - self.next_review_date.min.replace(tzinfo=self.next_review_date.tzinfo)).seconds
+        seconds = (
+            self.next_review_date - self.next_review_date.min.replace(tzinfo=self.next_review_date.tzinfo)).seconds
         rounding = (seconds + round_to) // round_to * round_to
         self.next_review_date = self.next_review_date + timedelta(0, rounding - seconds, 0)
 
-        logger.debug("Updating Next Review Time for user {} for review {}. Went from {} to {}, a rounding of {:.1f} minutes"
-                     .format(self.user,
-                             self.vocabulary.meaning,
-                             original_date.strftime("%H:%M:%S"),
-                             self.next_review_date.strftime("%H:%M:%S"),
-                             (self.next_review_date - original_date).total_seconds() / 60))
+        logger.debug(
+            "Updating Next Review Time for user {} for review {}. Went from {} to {}, a rounding of {:.1f} minutes"
+                .format(self.user,
+                        self.vocabulary.meaning,
+                        original_date.strftime("%H:%M:%S"),
+                        self.next_review_date.strftime("%H:%M:%S"),
+                        (self.next_review_date - original_date).total_seconds() / 60))
         self.save()
 
     def __str__(self):

--- a/kw_webapp/tasks.py
+++ b/kw_webapp/tasks.py
@@ -185,7 +185,6 @@ def sync_user_profile_with_wk(user):
         json_data = r.json()
         try:
             user_info = json_data["user_information"]
-            user.profile.level = user_info["level"]
             user.profile.title = user_info["title"]
             user.profile.join_date = datetime.utcfromtimestamp(user_info["creation_date"])
             user.profile.topics_count = user_info["topics_count"]
@@ -195,6 +194,12 @@ def sync_user_profile_with_wk(user):
             user.profile.set_twitter_account(user_info["twitter"])
             if user.profile.follow_me:
                 user.profile.unlocked_levels.get_or_create(level=user_info["level"])
+                if user_info["level"] < user.profile.level: #we have detected a user reset on WK
+                    user.profile.handle_wanikani_reset(user_info["level"])
+                else:
+                    user.profile.level = user_info["level"]
+
+
             user.profile.gravatar = user_info["gravatar"]
             user.profile.api_valid = True
             user.profile.save()


### PR DESCRIPTION
Fixes users who reset WK. Now, on detection of down-level, we remove the offending levels and reviews, assuming the user has "follow WK" enabled. 