### PR TITLE
added auto show answers when correct toggle in settings

### DIFF
--- a/_front-end/src/assets/toolkit/scripts/sections/reviews.js
+++ b/_front-end/src/assets/toolkit/scripts/sections/reviews.js
@@ -197,13 +197,16 @@ function compareAnswer() {
   const getMatchedReading = (hiraganaStr) => currentVocab.characters[currentVocab.readings.indexOf(hiraganaStr)]
 
   if (inReadings() || inCharacters()) {
+    let advanceDelay = 850;
     markRight();
     //Fills the correct kanji into the input field based on the user's answers
-    if (wanakana.isHiragana(answer)) {
-	   	$userAnswer.val(getMatchedReading(answer));
-	  }
+    if (wanakana.isHiragana(answer)) $userAnswer.val(getMatchedReading(answer));
     processAnswer({correct: true});
-    if (KW.settings.autoAdvanceCorrect) setTimeout(() => enterPressed(), 900);
+    if (KW.settings.showCorrectOnSuccess) {
+      revealAnswers();
+      if (KW.settings.autoAdvanceCorrect) advanceDelay = 1400;
+    }
+    if (KW.settings.autoAdvanceCorrect) setTimeout(() => enterPressed(), advanceDelay);
   }
   //answer was not in the known readings.
   else {

--- a/_front-end/src/assets/toolkit/scripts/sections/reviews.js
+++ b/_front-end/src/assets/toolkit/scripts/sections/reviews.js
@@ -199,9 +199,9 @@ function compareAnswer() {
   if (inReadings() || inCharacters()) {
     let advanceDelay = 850;
     markRight();
+    processAnswer({correct: true});
     //Fills the correct kanji into the input field based on the user's answers
     if (wanakana.isHiragana(answer)) $userAnswer.val(getMatchedReading(answer));
-    processAnswer({correct: true});
     if (KW.settings.showCorrectOnSuccess) {
       revealAnswers();
       if (KW.settings.autoAdvanceCorrect) advanceDelay = 1400;

--- a/kw_webapp/forms.py
+++ b/kw_webapp/forms.py
@@ -90,7 +90,7 @@ class UserCreateForm(UserCreationForm):
 class SettingsForm(ModelForm):
     class Meta:
         model = Profile
-        fields = ['api_key', 'level',  'follow_me', 'auto_advance_on_success', 'auto_expand_answer_on_failure', 'only_review_burned', 'on_vacation']
+        fields = ['api_key', 'level',  'follow_me', 'auto_advance_on_success', 'auto_expand_answer_on_success', 'auto_expand_answer_on_failure', 'only_review_burned', 'on_vacation']
         help_texts = {
             "follow_me": ("If you disable this, Kaniwani will no longer automatically unlock things as you unlock them in Wanikani."),
             "on_vacation": ("Enabling this setting will prevent your reviews from accumulating.")
@@ -98,6 +98,7 @@ class SettingsForm(ModelForm):
         labels = {
             "follow_me": "Follow Wanikani Progress",
             "auto_advance_on_success": "Automatically advance to next item in review if answer was correct.",
+            "auto_expand_answer_on_success": "Automatically show kanji and kana if you answer correctly.",
             "auto_expand_answer_on_failure": "Automatically show kanji and kana if you answer incorrectly.",
             "only_review_burned": "Review only items that you have burned in Wanikani.",
             "on_vacation": "Vacation Mode"

--- a/kw_webapp/migrations/0012_profile_auto_expand_answer_on_success.py
+++ b/kw_webapp/migrations/0012_profile_auto_expand_answer_on_success.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('kw_webapp', '0011_vacation_settings'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='profile',
+            name='auto_expand_answer_on_success',
+            field=models.BooleanField(default=False),
+        ),
+    ]

--- a/kw_webapp/models.py
+++ b/kw_webapp/models.py
@@ -54,8 +54,9 @@ class Profile(models.Model):
     # General user-changeable settings
     unlocked_levels = models.ManyToManyField(Level)
     follow_me = models.BooleanField(default=True)
-    auto_expand_answer_on_failure = models.BooleanField(default=False)
     auto_advance_on_success = models.BooleanField(default=False)
+    auto_expand_answer_on_success = models.BooleanField(default=False)
+    auto_expand_answer_on_failure = models.BooleanField(default=False)
     only_review_burned = models.BooleanField(default=False)
 
     # Vacation Settings

--- a/kw_webapp/templates/kw_webapp/base.html
+++ b/kw_webapp/templates/kw_webapp/base.html
@@ -66,6 +66,7 @@
       settings: {
         onVacation: '{{ user.profile.on_vacation }}',
         showCorrectOnFail: '{{ user.profile.auto_expand_answer_on_failure }}',
+        showCorrectOnSuccess: '{{ user.profile.auto_expand_answer_on_success }}',
         autoAdvanceCorrect: '{{ user.profile.auto_advance_on_success }}',
         followWanikani: '{{ user.follow_me }}',
         burnedOnly: '{{ user.only_review_burned }}'


### PR DESCRIPTION
added this because I'm mainly using IME for answers now - and can't use the keyboard shortcuts to show info. We can't accurately detect the keydown event (since an "F" keypress is intercepted by the IME to begin autocompletion as far as I can tell). I've tried matchin the japanese ｆ unicode for example but no luck.

I remember someone requested this feature a while back anyway, so why not.

Auto advance mode is intentionally twice as slow (~1400ms) when combined with auto-show-correct to provide a slightly longer glance at the answers

@tadgh Not sure what tests you have for the settings - you probably don't need one for this since it's a pure boolean toggle - and the effect is entirely front end. Take a quick look and see if I've missed anything.