### PR TITLE
Feature/better auto advance

### DIFF
--- a/_front-end/.eslintrc
+++ b/_front-end/.eslintrc
@@ -1,13 +1,26 @@
 {
-  'extends': 'airbnb',
-  'rules' : {
-    'id-length': [1, {'min': 2, 'properties': 'never', 'exceptions': ['s','v','i','a','b','x','y','o']}],
-    'quote-props': [1, 'consistent-as-needed'],
-    'no-cond-assign': [2, 'except-parens'],
-    'space-infix-ops': 0,
-    'no-unused-vars': [1, {'vars': 'local', 'args': 'none'}],
-    'default-case': 0,
-    'no-param-reassign': 1,
-    'quotes': [1, "single", "avoid-escape"]
+  "extends": "airbnb",
+  "env": {
+    "browser": "true",
+    "node": "true"
+  },
+  "rules" : {
+    "id-length": [1, {
+      "min": 2,
+      "properties": "never",
+      "exceptions": ["$", "_", "s", "o", "v", "i", "a", "b", "x", "y"]
+    }],
+    "no-use-before-define": ["error", { "functions": false, "classes": true }],
+    "quote-props": [1, "consistent-as-needed"],
+    "no-cond-assign": [2, "except-parens"],
+    "space-infix-ops": 0,
+    "spaced-comment": 1,
+    "no-unused-vars": [1, {
+      "vars": "local",
+      "args": "none"
+    }],
+    "default-case": 0,
+    "no-param-reassign": 1,
+    "quotes": [1, "single", "avoid-escape"]
   }
 }

--- a/_front-end/gulpfile.js
+++ b/_front-end/gulpfile.js
@@ -21,7 +21,6 @@ var assemble = require('fabricator-assemble'),
     lost = require('lost'),
     autoprefixer = require('autoprefixer'),
     browserSync = require('browser-sync'),
-    spawn = require('child_process').spawn, // for casper tests
     reload = browserSync.reload;
 
 
@@ -141,23 +140,6 @@ gulp.task('stripDebug', function () {
 
 });
 
-// functionality tests
-gulp.task('test', function () {
-    var tests = ['test/test.js'];
-
-    var casperChild = spawn('casperjs', ['test'].concat(tests));
-
-    casperChild.stdout.on('data', function (data) {
-        gutil.log('CasperJS:', data.toString().slice(0, -1)); // Remove \n
-    });
-
-    casperChild.on('close', function (code) {
-        var success = code === 0; // Will be 1 in the event of failure
-
-        // Do something with success here
-    });
-});
-
 // server
 gulp.task('serve', function () {
 
@@ -226,7 +208,7 @@ gulp.task('default', ['clean'], function () {
     }
 
     if (config.prod) {
-     gulp.start('stripDebug');
+     // gulp.start('stripDebug');
     }
   });
 

--- a/_front-end/src/assets/toolkit/scripts/components/refreshReviews.js
+++ b/_front-end/src/assets/toolkit/scripts/components/refreshReviews.js
@@ -1,4 +1,6 @@
-import pluralize from '../util/pluralize.js';
+import pluralize from '../util/pluralize';
+import kwlog from '../util/kwlog';
+
 
 let $navCount,
     $buttonCount,
@@ -15,7 +17,7 @@ function ajaxReviewCount() {
         if ($buttonCount.length) $buttonCount.text(pluralize('Review', res)).removeClass('-disabled');
       }
 
-      console.log('Review count updated from server:', res)
+      kwlog('Review count updated from server:', res)
       simpleStorage.set('recentlyRefreshed', true, {TTL: 19000}); // 19s throttle (updateReviewTime on 20s loop)
   });
 }
@@ -25,7 +27,7 @@ let refreshReviews = function({forceGet} = {forceGet: false}) {
   $buttonCount = $("#reviewCount");
   recentlyRefreshed = simpleStorage.get('recentlyRefreshed');
 
-  console.log(`
+  kwlog(`
     --- Refresh reviews attempted to be called ---
     recentlyRefreshed: ${recentlyRefreshed}, forceGet: ${forceGet}
     Are we hitting server? ${!recentlyRefreshed || forceGet ? 'yes' : 'no'}

--- a/_front-end/src/assets/toolkit/scripts/sections/levelVocab.js
+++ b/_front-end/src/assets/toolkit/scripts/sections/levelVocab.js
@@ -1,6 +1,8 @@
 import config from '../config';
 import im from '../vendor/include-media';
 import toastr from '../vendor/toastr';
+import kwlog from '../util/kwlog';
+
 
 let CSRF;
 
@@ -58,7 +60,7 @@ function handleIconClick(event) {
       // brittle selecting, but user synonyms always have both present so it's safe unless markup changes...
       [$icon.closest('.kanji'), $icon.closest('.kanji').prev('.kana')].forEach(el => $(el).fadeOut(600));
     })
-    .always(res => console.log(res));
+    .always(res => kwlog(res));
   }
 
   function toggleLock(id) {
@@ -70,7 +72,7 @@ function handleIconClick(event) {
       $card.toggleClass('-locked -unlockable');
       $icon.toggleClass('i-unlock').toggleClass('i-unlocked');
     })
-    .always(res => console.log(res));
+    .always(res => kwlog(res));
   }
 }
 

--- a/_front-end/src/assets/toolkit/scripts/sections/reviews.js
+++ b/_front-end/src/assets/toolkit/scripts/sections/reviews.js
@@ -12,6 +12,13 @@ modals.init({ backspaceClose: false, callbackOpen: synonymModal });
 // and have much better organisation / handling of state
 
 
+function debuglogger(...args) {
+  if (window.KWDEBUG === true) {
+    console.log(...args);
+  }
+}
+
+
 let KW,
     currentVocab,
     remainingVocab,
@@ -74,7 +81,7 @@ function init() {
 
   // DEBUG
   $userAnswer.keypress(function(event) {
-    console.log('kp', event.which, String.fromCharCode(event.which));
+    debuglogger('kp', event.which, String.fromCharCode(event.which));
   });
 
   $synonymButton.click(synonymModal);
@@ -177,14 +184,14 @@ function emptyString(str) {
 }
 
 function compareAnswer() {
-  console.log('compareAnswer called');
+  debuglogger('compareAnswer called');
   let imeInput = false;
   answer = $userAnswer.val().trim();
 
   if (emptyString(answer)) return;
 
-  console.log('Comparing', answer, 'with vocab item:')
-  console.table(currentVocab);
+  debuglogger('Comparing', answer, 'with vocab item:')
+  if (window.KWDEBUG === true) console.table(currentVocab);
 
   addTerminalN(answer);
 
@@ -226,7 +233,7 @@ function compareAnswer() {
 }
 
 function synonymModal() {
-  console.log('synonymModal called');
+  debuglogger('synonymModal called');
   let $form = $('#synonymForm');
   let $answerField = $(wanakana.isHiragana(answer) ? '#newKana' : '#newKanji');
   let $notAnswerField = $('.input').not($answerField);
@@ -245,7 +252,7 @@ function synonymModal() {
 }
 
 function handleSynonymForm(ev) {
-  console.log('handleSynonymForm called');
+  debuglogger('handleSynonymForm called');
   ev.preventDefault();
   let $this = $(this);
   let vocabID = currentVocab.user_specific_id;
@@ -280,12 +287,12 @@ function addSynonym(vocabID, {kana, kanji} = {}) {
     kanji: kanji,
   })
   .always(res => {
-    console.log(res);
+    debuglogger(res);
   });
 }
 
 function processAnswer({correct} = {}) {
-  console.log('processAnswer called')
+  debuglogger('processAnswer called')
   let previouslyWrong,
       currentvocabID = currentVocab.user_specific_id;
 
@@ -319,12 +326,12 @@ function recordAnswer(vocabID, correctness, previouslyWrong) {
       wrong_before: previouslyWrong
     })
     .always(res => {
-      console.log(res);
+      debuglogger(res);
     });
 }
 
 function ignoreAnswer({ animate = true } = {}) {
-  console.log('ignoreAnswer called')
+  debuglogger('ignoreAnswer called')
   if (animate) {
     $userAnswer.addClass('shake');
     setTimeout(() => rotateVocab({ ignored: true }), 600);
@@ -395,14 +402,14 @@ function revealAnswers({kana, kanji} = {}) {
 }
 
 function rotateVocab({ignored = false, correct = false} = {}) {
-  console.log('rotateVocab called')
+  debuglogger('rotateVocab called')
   if (ignored) {
     // put ignored answer back onto end of review queue
     remainingVocab.push(currentVocab);
   }
 
   if (remainingVocab.length === 0) {
-    // console.log('Summary post data', answerCorrectness);
+    // debuglogger('Summary post data', answerCorrectness);
     return postSummary('/kw/summary/', answerCorrectness);
   }
 
@@ -415,7 +422,7 @@ function rotateVocab({ignored = false, correct = false} = {}) {
 
   // guard against 0 / 0 (when first answer ignored)
   let percentCorrect = Math.floor((correctTotal / answeredTotal) * 100) || 0;
-  // console.log(`
+  // debuglogger(`
   //   remainingVocab.length: ${remainingVocab.length},
   //   currentVocab: ${currentVocab.meaning},
   //   correctTotal: ${correctTotal},
@@ -431,7 +438,7 @@ function rotateVocab({ignored = false, correct = false} = {}) {
 }
 
 function enterPressed(event, auto = false) {
-  console.log('eP:', event, 'auto?', auto);
+  debuglogger('eP:', event, 'auto?', auto);
   if (event != null) {
     event.stopPropagation();
     event.preventDefault();
@@ -451,45 +458,45 @@ function enterPressed(event, auto = false) {
 
 function handleShortcuts(ev) {
   if (ev.which === 13) {
-    console.log('handleShortcuts: 13;', 'event was:', ev)
+    debuglogger('handleShortcuts: not -marked, 13;')
     ev.stopPropagation();
     ev.preventDefault();
     enterPressed(null);
   } else if ($userAnswer.hasClass('-marked')) {
-    console.log('handleShortcuts: -marked not 13;', 'ev was:', ev)
+    debuglogger('handleShortcuts: -marked, not 13;')
     ev.stopPropagation();
     ev.preventDefault();
 
     switch(true) {
       // Pressing P toggles phonetic reading
       case (ev.which === 80 || ev.which === 112):
-        console.log('case: P', 'event was:', ev);
+        debuglogger('case: P', 'event was:', ev);
         revealAnswers({kana: true});
         break;
       // Pressing K toggles the actual kanji reading.
       case (ev.which === 75 || ev.which === 107):
-        console.log('case: K', 'event was:', ev);
+        debuglogger('case: K', 'event was:', ev);
         revealAnswers({kanji: true});
         break;
       // Pressing F toggles both item info boxes.
       case (ev.which === 70 || ev.which === 102):
-        console.log('case: F', 'event was:', ev);
+        debuglogger('case: F', 'event was:', ev);
         revealAnswers();
         break;
       // Pressing S toggles both add synonym modal.
       case (ev.which === 83 || ev.which === 115):
-        console.log('case: S', 'event was:', ev);
+        debuglogger('case: S', 'event was:', ev);
         modals.openModal(null, '#newSynonym', {
           backspaceClose: false, callbackOpen: synonymModal
         });
         break;
-      // Pressing I or backspace/del ignores answer when input has been marked incorrect
-      case (ev.which === 73 || ev.which === 105 || ev.which === 8 || ev.which === 46):
-        console.log('case: I', 'event was:', ev);
+      // Pressing I ignores answer when input has been marked incorrect
+      case (ev.which === 73 || ev.which === 105):
+        debuglogger('case: I', 'event was:', ev);
         if ($userAnswer.hasClass('-incorrect')) ignoreAnswer();
         break;
       default:
-        console.log('switch through to default');
+        debuglogger('switch through to default');
     }
   }
 }

--- a/_front-end/src/assets/toolkit/scripts/sections/reviews.js
+++ b/_front-end/src/assets/toolkit/scripts/sections/reviews.js
@@ -43,8 +43,12 @@ const answerCorrectness = [];
 // http://www.rikai.com/library/kanjitables/kanji_codes.unicode.shtml
 // not including *half-width katakana / roman letters* since they should be considered typos
 const japRegex = /[\u3000-\u303f\u3040-\u309f\u30a0-\u30ff\u4e00-\u9faf\u3400-\u4dbf]/;
-const onlyJapaneseChars = str => [...str].every(c => japRegex.test(c));
-const onlyKanji = str => [...str].every(c => c.charCodeAt(0) >= 19968 && c.charCodeAt(0) < 40879);
+function onlyJapaneseChars(str) {
+  return [...str].every(char => japRegex.test(char));
+}
+function onlyKanji(str) {
+  return [...str].every(char => char.charCodeAt(0) >= 19968 && char.charCodeAt(0) < 40879);
+}
 // Grab CSRF token off of dummy form.
 const CSRF = $('#csrf').val();
 
@@ -139,7 +143,7 @@ function postSummary(path, params) {
   // TODO: this is crazytown, treating an array as an object - need to refactor
   for (let key in params) {
     if (params.hasOwnProperty(key)) {
-      let hiddenField = document.createElement('input');
+      const hiddenField = document.createElement('input');
       hiddenField.setAttribute('type', 'hidden');
       hiddenField.setAttribute('name', key);
       hiddenField.setAttribute('value', params[key]);
@@ -157,7 +161,7 @@ function postSummary(path, params) {
   form.submit();
 }
 
-String.prototype.endsWith = function(suffix) {
+String.prototype.endsWith = function (suffix) {
   return this.indexOf(suffix, this.length - suffix.length) !== -1;
 };
 
@@ -184,7 +188,6 @@ function emptyString(str) {
 
 function compareAnswer() {
   kwlog('compareAnswer called');
-  let imeInput = false;
   answer = $userAnswer.val().trim();
 
   if (emptyString(answer)) return;
@@ -196,7 +199,6 @@ function compareAnswer() {
 
   if (onlyJapaneseChars(answer)) {
     // user used japanese IME, proceed
-    imeInput = true;
     if (currentVocab.characters[0].startsWith('〜') && onlyKanji(answer)) addStartingTilde(answer);
   } else if (!wanakana.isHiragana(answer)) {
     // user used english that couldn't convert to full hiragana - don't proceed
@@ -210,8 +212,8 @@ function compareAnswer() {
   if (inReadings() || inCharacters()) {
     let advanceDelay = 800;
     markRight();
-    processAnswer({correct: true});
-    //Fills the correct kanji into the input field based on the user's answers
+    processAnswer({ correct: true });
+    // Fills the correct kanji into the input field based on the user's answers
     if (wanakana.isHiragana(answer)) $userAnswer.val(getMatchedReading(answer));
     if (KW.settings.showCorrectOnSuccess) {
       revealAnswers();
@@ -224,10 +226,7 @@ function compareAnswer() {
       },
       advanceDelay);
     }
-  }
-
-  // answer was not in the known readings.
-  else {
+  } else {
     markWrong();
     // don't processAnswer() here
     // wait for submission or ignore answer - which is handled by event listeners for submit/enter
@@ -299,7 +298,7 @@ function addSynonym(vocabID, { kana, kanji } = {}) {
   });
 }
 
-function processAnswer({correct} = {}) {
+function processAnswer({ correct } = {}) {
   kwlog('processAnswer called');
   const currentvocabID = currentVocab.user_specific_id;
   let previouslyWrong;

--- a/_front-end/src/assets/toolkit/scripts/sections/reviews.js
+++ b/_front-end/src/assets/toolkit/scripts/sections/reviews.js
@@ -100,6 +100,7 @@ function getSrsRank(num) {
 
 function updateStreak() {
   const rank = getSrsRank(currentVocab.streak);
+  // using .attr('class') to completely wipe prev classes on update
   $streakIcon.attr('class', `icon i-${rank}`);
   $streakIcon.closest('.streak').attr('data-hint', `${rank}`);
 }
@@ -116,7 +117,8 @@ function streakLevelUp() {
   if (newRank !== rank) {
     $srsUp.attr('data-after', newRank).addClass(`-animating -${newRank}`);
     $streakIcon.attr('class', `icon i-${newRank} -marked`)
-               .closest('.streak').attr('data-hint', `${newRank}`);
+               .closest('.streak')
+               .attr('data-hint', `${newRank}`);
   }
 }
 
@@ -129,8 +131,9 @@ function earlyTermination(ev) {
   ev.preventDefault();
   if (answeredTotal === 0) {
     window.location = '/kw/';
+  } else {
+    postSummary('/kw/summary/', answerCorrectness);
   }
-  postSummary('/kw/summary/', answerCorrectness);
 }
 
 function postSummary(path, params) {
@@ -304,11 +307,10 @@ function processAnswer({ correct } = {}) {
   let previouslyWrong;
 
   if (correct === true) {
-
     // Ensures this is the first time the vocab has been answered in this session,
     // so it goes in the right container(incorrect/correct)
 
-    // TODO: this is crazytown, treating an array as an object - need to refactor
+    // TODO: this is crazytown, treating an array as an object - need to refactor as obj
     if ($.inArray(currentvocabID, Object.keys(answerCorrectness)) === -1) {
       answerCorrectness[currentvocabID] = 1;
       previouslyWrong = false;
@@ -441,13 +443,13 @@ function rotateVocab({ ignored = false, correct = false } = {}) {
 
   // guard against 0 / 0 (when first answer ignored)
   const percentCorrect = Math.floor((correctTotal / answeredTotal) * 100) || 0;
-  // kwlog(`
-  //   remainingVocab.length: ${remainingVocab.length},
-  //   currentVocab: ${currentVocab.meaning},
-  //   correctTotal: ${correctTotal},
-  //   answeredTotal: ${answeredTotal},
-  //   percentCorrect: ${percentCorrect}`
-  // );
+  kwlog(`
+    remainingVocab.length: ${remainingVocab.length},
+    currentVocab: ${currentVocab.meaning},
+    correctTotal: ${correctTotal},
+    answeredTotal: ${answeredTotal},
+    percentCorrect: ${percentCorrect}`
+  );
 
   // TODO: this is slightly off if user ignored incorrect answer - need to account for that
   $reviewsCorrect.html(percentCorrect);

--- a/_front-end/src/assets/toolkit/scripts/sections/reviews.js
+++ b/_front-end/src/assets/toolkit/scripts/sections/reviews.js
@@ -135,16 +135,18 @@ function postSummary(path, params) {
   form.setAttribute('action', path);
   form.setAttribute('class', 'u-visuallyhidden');
 
-  console.log(params)
-  params.forEach(param => {
-    console.log(param, params[param])
-    const hiddenField = document.createElement('input');
-    hiddenField.setAttribute('type', 'hidden');
-    hiddenField.setAttribute('name', params[val]);
-    hiddenField.setAttribute('value', params[param]);
 
-    form.appendChild(hiddenField);
-  });
+  // TODO: this is crazytown, treating an array as an object - need to refactor
+  for (let key in params) {
+    if (params.hasOwnProperty(key)) {
+      let hiddenField = document.createElement('input');
+      hiddenField.setAttribute('type', 'hidden');
+      hiddenField.setAttribute('name', key);
+      hiddenField.setAttribute('value', params[key]);
+
+      form.appendChild(hiddenField);
+    }
+  }
 
   // CSRF hackery.
   const CsrfField = document.createElement('input');
@@ -303,8 +305,11 @@ function processAnswer({correct} = {}) {
   let previouslyWrong;
 
   if (correct === true) {
+
     // Ensures this is the first time the vocab has been answered in this session,
     // so it goes in the right container(incorrect/correct)
+
+    // TODO: this is crazytown, treating an array as an object - need to refactor
     if ($.inArray(currentvocabID, Object.keys(answerCorrectness)) === -1) {
       answerCorrectness[currentvocabID] = 1;
       previouslyWrong = false;

--- a/_front-end/src/assets/toolkit/scripts/sections/reviews.js
+++ b/_front-end/src/assets/toolkit/scripts/sections/reviews.js
@@ -207,19 +207,22 @@ function compareAnswer() {
 
   const inReadings = () => $.inArray(answer, currentVocab.readings) != -1;
   const inCharacters = () => $.inArray(answer, currentVocab.characters) != -1;
-  const getMatchedReading = (hiraganaStr) => currentVocab.characters[currentVocab.readings.indexOf(hiraganaStr)]
+  const getMatchedReading = (hiraganaStr) => currentVocab.characters[currentVocab.readings.indexOf(hiraganaStr)];
 
   if (inReadings() || inCharacters()) {
-    let advanceDelay = 850;
+    let advanceDelay = 800;
     markRight();
     processAnswer({correct: true});
     //Fills the correct kanji into the input field based on the user's answers
     if (wanakana.isHiragana(answer)) $userAnswer.val(getMatchedReading(answer));
     if (KW.settings.showCorrectOnSuccess) {
       revealAnswers();
-      if (KW.settings.autoAdvanceCorrect) advanceDelay = 1400;
+      if (KW.settings.autoAdvanceCorrect) advanceDelay = 1200;
     }
-    if (KW.settings.autoAdvanceCorrect) setTimeout(() => enterPressed(null, true), advanceDelay);
+    if (KW.settings.autoAdvanceCorrect) setTimeout(() => {
+      enterPressed(null, true);
+      },
+    advanceDelay);
   }
   //answer was not in the known readings.
   else {

--- a/_front-end/src/assets/toolkit/scripts/util/kwlog.js
+++ b/_front-end/src/assets/toolkit/scripts/util/kwlog.js
@@ -1,0 +1,8 @@
+// only log is debug turned on
+const kwlog = function (...args) {
+  if (window.KWDEBUG === true) {
+    console.log(...args);
+  }
+};
+
+export default kwlog;

--- a/kw_webapp/templates/kw_webapp/reviewsummary.html
+++ b/kw_webapp/templates/kw_webapp/reviewsummary.html
@@ -12,14 +12,6 @@
       <span class="percentage"></span>
     </div>
 
-    <p> {{incorrect_count}} {{correct_count}} </p>
-
-    {% if incorrect_count < 0 and correct_count < 0 %}
-    <h2 class="title">
-      Nothing answered, nothing gained!
-    </h2>
-    {% endif %}
-
     {% if incorrect_count > 0 %}
     <h2 class="title">{{ incorrect_count }} Incorrect</h2>
       <ul class="vocab-list -incorrect">
@@ -40,7 +32,7 @@
         {% endfor %}
       </ul>
 
-    {% elif incorrect_count < 1 and correct_count > 1 %}
+    {% else %}
       <h3 class="title"><span lang="ja">完璧だ！</span> (๑•̀ㅂ•́)و</h3>
     {% endif %}
 
@@ -58,7 +50,7 @@
         {% endfor %}
       </ul>
 
-    {% elif correct_count < 1 and incorrect_count > 1 %}
+    {% else %}
       <h3 class="title"><span lang="ja">残念だよ</span> (๑◕︵◕๑)</h3>
     {% endif %}
 

--- a/kw_webapp/templates/kw_webapp/reviewsummary.html
+++ b/kw_webapp/templates/kw_webapp/reviewsummary.html
@@ -12,6 +12,14 @@
       <span class="percentage"></span>
     </div>
 
+    <p> {{incorrect_count}} {{correct_count}} </p>
+
+    {% if incorrect_count < 0 and correct_count < 0 %}
+    <h2 class="title">
+      Nothing answered, nothing gained!
+    </h2>
+    {% endif %}
+
     {% if incorrect_count > 0 %}
     <h2 class="title">{{ incorrect_count }} Incorrect</h2>
       <ul class="vocab-list -incorrect">
@@ -32,7 +40,7 @@
         {% endfor %}
       </ul>
 
-    {% else %}
+    {% elif incorrect_count < 1 and correct_count > 1 %}
       <h3 class="title"><span lang="ja">完璧だ！</span> (๑•̀ㅂ•́)و</h3>
     {% endif %}
 
@@ -50,7 +58,7 @@
         {% endfor %}
       </ul>
 
-    {% else %}
+    {% elif correct_count < 1 and incorrect_count > 1 %}
       <h3 class="title"><span lang="ja">残念だよ</span> (๑◕︵◕๑)</h3>
     {% endif %}
 


### PR DESCRIPTION
* Improves auto-advance feature by disabling it if the user manually advances before it fires.
* Handle shortcuts better by enabling them only after an answer is marked correct/incorrect.
* Disable shortcuts when user is answering a question, adding synonym via modal etc
* Disable answer input after it is marked - user shouldn't be able to modify answer text when they can't resubmit anyway.
* Previously we listened for shortcuts on the input field, now we listen on the document to capture bubbled events instead (less chance of interfering with WanaKana input binding).